### PR TITLE
added getElementNames function to SignalLoggerBase

### DIFF
--- a/signal_logger_core/include/signal_logger_core/SignalLoggerBase.hpp
+++ b/signal_logger_core/include/signal_logger_core/SignalLoggerBase.hpp
@@ -29,7 +29,9 @@
 #include <condition_variable>
 #include <atomic>
 #include <memory>
+#include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <functional>
 
 namespace signal_logger {
@@ -116,6 +118,12 @@ class SignalLoggerBase {
    * @return const log element reference
    */
   const LogElementInterface & getElement(const std::string & name);
+
+  /**
+ * @brief Gets a unordered set containing the names of all elements
+ * @return unordered set containing all element names as strings
+ */
+  std::unordered_set<std::string>  getElementNames();
 
   /**
    * @brief Enables the element if:

--- a/signal_logger_core/src/SignalLoggerBase.cpp
+++ b/signal_logger_core/src/SignalLoggerBase.cpp
@@ -430,6 +430,16 @@ const LogElementInterface & SignalLoggerBase::getElement(const std::string & nam
   return *logElements_[name];
 }
 
+std::unordered_set<std::string> SignalLoggerBase::getElementNames()
+{
+  boost::shared_lock<boost::shared_mutex> lockLogger(loggerMutex_);
+  std::unordered_set<std::string> element_names {};
+  for (const auto & element: logElements_) {
+    element_names.insert(element.first);
+  }
+  return element_names;
+}
+
 bool SignalLoggerBase::enableElement(const std::string & name)
 {
   boost::upgrade_lock<boost::shared_mutex> lockLogger(loggerMutex_);


### PR DESCRIPTION
This change provides a function to get all element names of members that the signal logger is currently collecting. This is needed for the log plugin of AnyExo. Please refer to Yves Zimmermann for any questions.